### PR TITLE
Remove leading spaces in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-    description-file = README.md
+description-file = README.md


### PR DESCRIPTION
The leading spaces in setup.cfg cause an error when running setup.py:

``` bash
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 34, in <module>
    'pockyt=pockyt.pockyt:main',
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 125, in setup
    dist.parse_config_files()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 390, in parse_config_files
    parser.read(filename)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ConfigParser.py", line 305, in read
    self._read(fp, filename)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ConfigParser.py", line 546, in _read
    raise e
ConfigParser.ParsingError: File contains parsing errors: setup.cfg
    [line  2]: '    description-file = README.md\n'
```

This commit removes them.
