### PR TITLE
specify charset in POST to API

### DIFF
--- a/pockyt/wrapper.py
+++ b/pockyt/wrapper.py
@@ -128,7 +128,7 @@ class Network(object):
     def post_request(cls, link, payload):
         request_data = json.dumps(payload).encode(API.ENCODING)
         headers = {
-            "Content-Type": API.CONTENT_TYPE,
+            "Content-Type": "%s; charset=%s" % (API.CONTENT_TYPE, API.ENCODING.upper()),
             "Content-Length": len(request_data),
             "User-Agent": cls.USER_AGENT,
         }


### PR DESCRIPTION
Fix registration issue by specifying charset in POST as per https://getpocket.com/developer/docs/authentication